### PR TITLE
Econia rework v0.1. Return fill, cancel events.

### DIFF
--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -23,5 +23,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, since
 # event unit tests for this package were added before Aptos' event unit
 # testing framework was incorporated into the `mainnet` branch.
-rev = "mainnet"
+rev = "d0581988adf90db9893c9c0d0a7f015153ac4699"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -20,5 +20,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, since
 # event unit tests for this package were added before Aptos' event unit
 # testing framework was incorporated into the `mainnet` branch.
-rev = "d0581988adf90db9893c9c0d0a7f015153ac4699"
+rev = "mainnet"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -10,9 +10,6 @@ econia = "_"
 user = "0x1234"
 user_0 = "0x2345"
 user_1 = "0x3456"
-user_2 = "0x2222"
-user_3 = "0x3333"
-user_4 = "0x4444"
 integrator = "0x4567"
 
 [dev-addresses]

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -10,7 +10,13 @@ econia = "_"
 user = "0x1234"
 user_0 = "0x2345"
 user_1 = "0x3456"
+user_2 = "0x2222"
+user_3 = "0x3333"
+user_4 = "0x4444"
 integrator = "0x4567"
+
+[dev-addresses]
+econia = "0xdeaddead"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -662,7 +662,9 @@ module econia::market {
         /// Deprecated field retained for compatible upgrade policy.
         maker_events: EventHandle<MakerEvent>,
         /// Deprecated field retained for compatible upgrade policy.
-        taker_events: EventHandle<TakerEvent>
+        taker_events: EventHandle<TakerEvent>,
+        /// Only custodian functions can get access to orderbook
+        is_custodian: bool,
     }
 
     /// Order book map for all Econia order books.
@@ -853,7 +855,8 @@ module econia::market {
     const E_ORDER_DID_NOT_POST: u64 = 31;
     /// Order price field does not match AVL queue insertion key price.
     const E_ORDER_PRICE_MISMATCH: u64 = 32;
-
+    /// Place order on custodian market without custodian capabilities
+    const E_CUSTODIAN_MARKET: u64 = 33;
     // Error codes <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
     // Constants >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -1908,18 +1911,19 @@ module econia::market {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        utility_coins: Coin<UtilityType>
+        utility_coins: Coin<UtilityType>,
+        is_custodian: bool,
     ): u64
     acquires OrderBooks {
         // Register market in global registry, storing market ID.
         let market_id = registry::register_market_base_coin_internal<
             BaseType, QuoteType, UtilityType>(lot_size, tick_size, min_size,
-            utility_coins);
+            utility_coins, is_custodian);
         // Register order book and quote coin fee store, return market
         // ID.
         register_market<BaseType, QuoteType>(
             market_id, string::utf8(b""), lot_size, tick_size, min_size,
-            NO_UNDERWRITER)
+            NO_UNDERWRITER, is_custodian)
     }
 
     /// Register generic market, return resultant market ID.
@@ -1963,18 +1967,19 @@ module econia::market {
         tick_size: u64,
         min_size: u64,
         utility_coins: Coin<UtilityType>,
-        underwriter_capability_ref: &UnderwriterCapability
+        underwriter_capability_ref: &UnderwriterCapability,
+        is_custodian: bool,
     ): u64
     acquires OrderBooks {
         // Register market in global registry, storing market ID.
         let market_id = registry::register_market_base_generic_internal<
             QuoteType, UtilityType>(base_name_generic, lot_size, tick_size,
-            min_size, underwriter_capability_ref, utility_coins);
+            min_size, underwriter_capability_ref, utility_coins, false);
         // Register order book and quote coin fee store, return market
         // ID.
         register_market<GenericAsset, QuoteType>(
             market_id, base_name_generic, lot_size, tick_size, min_size,
-            registry::get_underwriter_id(underwriter_capability_ref))
+            registry::get_underwriter_id(underwriter_capability_ref), is_custodian)
     }
 
     /// Swap against the order book between a user's coin stores.
@@ -2565,13 +2570,14 @@ module econia::market {
         user: &signer,
         lot_size: u64,
         tick_size: u64,
-        min_size: u64
+        min_size: u64,
+        is_custodian: bool
     ) acquires OrderBooks {
         // Get market registration fee, denominated in utility coins.
         let fee = incentives::get_market_registration_fee();
         // Register market with base coin, paying fees from coin store.
         register_market_base_coin<BaseType, QuoteType, UtilityType>(
-            lot_size, tick_size, min_size, coin::withdraw(user, fee));
+            lot_size, tick_size, min_size, coin::withdraw(user, fee), is_custodian);
     }
 
     /// Public entry function wrapper for `swap_between_coinstores()`.
@@ -3544,6 +3550,9 @@ module econia::market {
             == order_book_ref_mut.base_type, E_INVALID_BASE);
         assert!(type_info::type_of<QuoteType>() // Assert quote type.
             == order_book_ref_mut.quote_type, E_INVALID_QUOTE);
+        if (order_book_ref_mut.is_custodian == true) {
+            assert!(custodian_id != NO_CUSTODIAN, E_CUSTODIAN_MARKET);
+        };
         // Assert order size is at least minimum size for market.
         assert!(size >= order_book_ref_mut.min_size, E_SIZE_TOO_SMALL);
         // Get market underwriter ID.
@@ -3907,6 +3916,9 @@ module econia::market {
              == order_book_ref.base_type, E_INVALID_BASE);
          assert!(type_info::type_of<QuoteType>() // Assert quote type.
              == order_book_ref.quote_type, E_INVALID_QUOTE);
+         if (order_book_ref.is_custodian == true) {
+             assert!(custodian_id != NO_CUSTODIAN, E_CUSTODIAN_MARKET);
+         };
          // Get option-packed maximum bid and minimum ask prices.
          let (max_bid_price_option, min_ask_price_option) =
              (avl_queue::get_head_key(&order_book_ref.bids),
@@ -4135,6 +4147,9 @@ module econia::market {
             == order_book_ref_mut.base_type, E_INVALID_BASE);
         assert!(type_info::type_of<QuoteType>() // Assert quote type.
             == order_book_ref_mut.quote_type, E_INVALID_QUOTE);
+        if (order_book_ref_mut.is_custodian == true) {
+            assert!(custodian_id != NO_CUSTODIAN, E_CUSTODIAN_MARKET);
+        };
         // Assert order size is at least minimum size for market.
         assert!(size >= order_book_ref_mut.min_size, E_SIZE_TOO_SMALL);
         // Calculate base asset amount corresponding to size in lots.
@@ -4355,7 +4370,8 @@ module econia::market {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        underwriter_id: u64
+        underwriter_id: u64,
+        is_custodian: bool
     ): u64
     acquires OrderBooks {
         // Get Econia resource account signer.
@@ -4365,7 +4381,7 @@ module econia::market {
         let order_books_map_ref_mut = // Mutably borrow order books map.
             &mut borrow_global_mut<OrderBooks>(resource_address).map;
         // Add order book entry to order books map.
-        tablist::add(order_books_map_ref_mut, market_id, OrderBook{
+        tablist::add(order_books_map_ref_mut, market_id, OrderBook {
             base_type: type_info::type_of<BaseType>(),
             base_name_generic,
             quote_type: type_info::type_of<QuoteType>(),
@@ -4377,9 +4393,11 @@ module econia::market {
             bids: avl_queue::new<Order>(DESCENDING, 0, 0),
             counter: 0,
             maker_events:
-                account::new_event_handle<MakerEvent>(&resource_account),
+            account::new_event_handle<MakerEvent>(&resource_account),
             taker_events:
-                account::new_event_handle<TakerEvent>(&resource_account)});
+            account::new_event_handle<TakerEvent>(&resource_account),
+            is_custodian }
+        );
         // Register an Econia fee store entry for market quote coin.
         incentives::register_econia_fee_store_entry<QuoteType>(market_id);
         market_id // Return market ID.
@@ -4858,14 +4876,14 @@ module econia::market {
         // Register pure coin market.
         register_market_base_coin<BC, QC, UC>(
             LOT_SIZE_COIN, TICK_SIZE_COIN, MIN_SIZE_COIN,
-            assets::mint_test(fee));
+            assets::mint_test(fee), false);
         let underwriter_capability = registry::get_underwriter_capability_test(
             UNDERWRITER_ID); // Get market underwriter capability.
         // Register generic market.
         register_market_base_generic<QC, UC>(
             string::utf8(BASE_NAME_GENERIC), LOT_SIZE_GENERIC,
             TICK_SIZE_GENERIC, MIN_SIZE_GENERIC, assets::mint_test(fee),
-            &underwriter_capability);
+            &underwriter_capability, false);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Set custodian IDs to be valid.
@@ -13562,7 +13580,7 @@ module econia::market {
         coin::deposit<UC>(@user, assets::mint_test(fee));
         // Register pure coin market from coinstore.
         register_market_base_coin_from_coinstore<BC, QC, UC>(
-            &user, LOT_SIZE_COIN, TICK_SIZE_COIN, MIN_SIZE_COIN);
+            &user, LOT_SIZE_COIN, TICK_SIZE_COIN, MIN_SIZE_COIN, false);
         // Get market info returns from registry.
         let (base_name_generic_r, lot_size_r, tick_size_r, min_size_r,
              underwriter_id_r) = registry::get_market_info_for_market_account(
@@ -13600,7 +13618,7 @@ module econia::market {
         let market_id = register_market_base_generic<QC, UC>(
             string::utf8(BASE_NAME_GENERIC), LOT_SIZE_GENERIC,
             TICK_SIZE_GENERIC, MIN_SIZE_GENERIC, assets::mint_test<UC>(fee),
-            &underwriter_capability);
+            &underwriter_capability, false);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert market ID.
@@ -13641,7 +13659,7 @@ module econia::market {
         // Assert market ID return for registering pure coin market not
         // from coin store.
         assert!(register_market_base_coin<QC, BC, UC>(
-            1, 1, 1, assets::mint_test<UC>(fee)) == 3, 0);
+            1, 1, 1, assets::mint_test<UC>(fee), false) == 3, 0);
     }
 
     #[test]
@@ -17328,6 +17346,109 @@ module econia::market {
         registry::drop_underwriter_capability_test(underwriter_capability);
     }
 
+    #[test_only]
+    fun init_custodian_generic_market(): (u64, signer, signer) acquires OrderBooks {
+        init_test(); // Init for testing.
+        // Get market registration fee.
+        let fee = incentives::get_market_registration_fee();
+        let underwriter_capability = registry::get_underwriter_capability_test(
+            UNDERWRITER_ID); // Get market underwriter capability.
+        // Register generic market.
+        register_market_base_generic<QC, UC>(
+            string::utf8(BASE_NAME_GENERIC), LOT_SIZE_GENERIC,
+            TICK_SIZE_GENERIC, MIN_SIZE_GENERIC, assets::mint_test(fee),
+            &underwriter_capability, true);
+        let market_id = 1;
+        // Drop underwriter capability.
+        registry::drop_underwriter_capability_test(underwriter_capability);
+        // Set custodian IDs to be valid.
+        registry::set_registered_custodian_test(CUSTODIAN_ID_USER_0);
+        registry::set_registered_custodian_test(CUSTODIAN_ID_USER_1);
+        let user_0 = account::create_account_for_test(@user_0);
+        user::register_market_account_generic_base<QC>(
+            &user_0, market_id, NO_CUSTODIAN);
+        user::register_market_account_generic_base<QC>(
+            &user_0, market_id, CUSTODIAN_ID_USER_0);
+        let user_1 = account::create_account_for_test(@user_1);
+        user::register_market_account_generic_base<QC>(
+            &user_1, market_id, NO_CUSTODIAN);
+        user::register_market_account_generic_base<QC>(
+            &user_1, market_id, CUSTODIAN_ID_USER_1);
+        // Register integrator to base fee store tier on each market.
+        let integrator = account::create_account_for_test(@integrator);
+        registry::register_integrator_fee_store_base_tier<QC, UC>(
+            &integrator, market_id);
+        (market_id, user_0, user_1)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_CUSTODIAN_MARKET)]
+    /// Verify failure for placing non custodian order to custodian market
+    fun test_custodian_market_invalid_order()
+    acquires
+    OrderBooks
+    {
+        let (market_id, user_0, _) = init_custodian_generic_market();
+
+        let size_maker          = MIN_SIZE_GENERIC;
+        let price = 1;
+        let self_match_behavior = ABORT;
+
+        let base_deposit_maker  = 100;
+
+        let underwriter_capability = registry::get_underwriter_capability_test(
+            UNDERWRITER_ID); // Get underwriter capability.
+
+        // Deposit maker assets.
+        user::deposit_generic_asset(
+            @user_0, market_id, NO_CUSTODIAN, base_deposit_maker,
+            &underwriter_capability);
+
+        // Place maker order.
+        let (_market_order_id_0, _, _, _) = place_limit_order_user<
+            GenericAsset, QC>(&user_0, market_id, @integrator,
+            ASK, size_maker, price, NO_RESTRICTION,
+            self_match_behavior);
+
+        // Drop underwriter capability.
+        registry::drop_underwriter_capability_test(underwriter_capability);
+    }
+
+
+    #[test]
+    /// Verify failure for placing non custodian order to custodian market
+    fun test_custodian_market_order()
+    acquires
+    OrderBooks
+    {
+        let (market_id, user_0, _) = init_custodian_generic_market();
+
+        let size_maker          = MIN_SIZE_GENERIC;
+        let price = 1;
+        let self_match_behavior = ABORT;
+
+        let base_deposit_maker  = 100;
+
+        let underwriter_capability = registry::get_underwriter_capability_test(
+            UNDERWRITER_ID); // Get underwriter capability.
+
+        // Deposit maker assets.
+        user::deposit_generic_asset(
+            @user_0, market_id, NO_CUSTODIAN, base_deposit_maker,
+            &underwriter_capability);
+        let custodian_capability = registry::get_custodian_capability_test(
+            CUSTODIAN_ID_USER_0); // Get custodian capability.
+        // Place maker order.
+        let (_market_order_id_0, _, _, _) = place_limit_order_custodian<
+            GenericAsset, QC>(address_of(&user_0), market_id, @integrator,
+            ASK, size_maker, price, NO_RESTRICTION,
+            self_match_behavior, &custodian_capability);
+
+        // Drop underwriter capability.
+        registry::drop_underwriter_capability_test(underwriter_capability);
+        // Drop custodian capability.
+        registry::drop_custodian_capability_test(custodian_capability);
+    }
     // Tests <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 }

--- a/src/move/econia/sources/registry.move
+++ b/src/move/econia/sources/registry.move
@@ -287,7 +287,11 @@ module econia::registry {
         /// underwriter capability required to verify generic asset
         /// amounts. A market-wide ID that only applies to markets
         /// having a generic base asset.
-        underwriter_id: u64
+        underwriter_id: u64,
+
+        /// Is this market full custodian.
+        /// Only custodian functions can place orders on full custodian markets
+        is_custodian: bool,
     }
 
     /// Human-readable market info return for view functions.
@@ -533,6 +537,7 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
+        is_custodian: bool,
     ): Option<u64>
     acquires Registry {
         get_market_id(MarketInfo{
@@ -542,7 +547,8 @@ module econia::registry {
             lot_size,
             tick_size,
             min_size,
-            underwriter_id: NO_UNDERWRITER
+            underwriter_id: NO_UNDERWRITER,
+            is_custodian
         })
     }
 
@@ -561,7 +567,8 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        underwriter_id: u64
+        underwriter_id: u64,
+        is_custodian: bool,
     ): Option<u64>
     acquires Registry {
         get_market_id(MarketInfo{
@@ -571,7 +578,8 @@ module econia::registry {
             lot_size,
             tick_size,
             min_size,
-            underwriter_id
+            underwriter_id,
+            is_custodian,
         })
     }
 
@@ -1339,7 +1347,8 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        utility_coins: Coin<UtilityCoinType>
+        utility_coins: Coin<UtilityCoinType>,
+        is_custodian: bool,
     ): u64
     acquires Registry {
         // Assert base coin type is initialized.
@@ -1348,7 +1357,7 @@ module econia::registry {
         // market ID.
         register_market_internal<QuoteCoinType, UtilityCoinType>(
             type_info::type_of<BaseCoinType>(), string::utf8(b""), lot_size,
-            tick_size, min_size, NO_UNDERWRITER, utility_coins)
+            tick_size, min_size, NO_UNDERWRITER, utility_coins, is_custodian)
     }
 
     /// Wrapped market registration call for a generic base type,
@@ -1377,7 +1386,8 @@ module econia::registry {
         tick_size: u64,
         min_size: u64,
         underwriter_capability_ref: &UnderwriterCapability,
-        utility_coins: Coin<UtilityCoinType>
+        utility_coins: Coin<UtilityCoinType>,
+        is_custodian: bool,
     ): u64
     acquires Registry {
         // Get generic asset name length.
@@ -1394,7 +1404,7 @@ module econia::registry {
         // market ID.
         register_market_internal<QuoteCoinType, UtilityCoinType>(
             type_info::type_of<GenericAsset>(), base_name_generic, lot_size,
-            tick_size, min_size, underwriter_id, utility_coins)
+            tick_size, min_size, underwriter_id, utility_coins, is_custodian)
     }
 
     // Public friend functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -1563,7 +1573,8 @@ module econia::registry {
         tick_size: u64,
         min_size: u64,
         underwriter_id: u64,
-        utility_coins: Coin<UtilityCoinType>
+        utility_coins: Coin<UtilityCoinType>,
+        is_custodian: bool,
     ): u64
     acquires Registry {
         // Assert lot size is nonzero.
@@ -1580,7 +1591,7 @@ module econia::registry {
         assert!(base_type != quote_type, E_BASE_QUOTE_SAME);
         let market_info = MarketInfo{ // Pack market info.
             base_type, base_name_generic, quote_type, lot_size, tick_size,
-            min_size, underwriter_id};
+            min_size, underwriter_id, is_custodian};
         // Mutably borrow registry.
         let registry_ref_mut = borrow_global_mut<Registry>(@econia);
         // Mutably borrow map from market info to market ID.
@@ -1753,10 +1764,10 @@ module econia::registry {
         // Register markets.
         let market_id_pure_coin = register_market_base_coin_internal<
             BC, QC, UC>(lot_size_pure_coin, tick_size_pure_coin,
-            min_size_pure_coin, assets::mint_test(fee));
+            min_size_pure_coin, assets::mint_test(fee), false);
         let market_id_generic = register_market_base_generic_internal<QC, UC>(
             base_name_generic_generic, lot_size_generic, tick_size_generic,
-            min_size_generic, &underwriter_capability, assets::mint_test(fee));
+            min_size_generic, &underwriter_capability, assets::mint_test(fee), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         // Return market info.
@@ -1809,7 +1820,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types.
@@ -1845,7 +1856,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types (invalid base).
@@ -1885,7 +1896,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types (wrong quote).
@@ -2074,11 +2085,11 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing market ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size - 1, tick_size, min_size, assets::mint_test(fee));
+            lot_size - 1, tick_size, min_size, assets::mint_test(fee), false);
         assert!(market_id == 1, 0); // Assert market ID.
         // Register another market, storing market ID.
         market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee));
+            lot_size, tick_size, min_size, assets::mint_test(fee), false);
         assert!(market_id == 2, 0); // Assert market ID.
         let markets_tablist_ref = // Immutably borrow markets tablist.
             &borrow_global<Registry>(@econia).market_id_to_info;
@@ -2117,12 +2128,12 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size - 1, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         assert!(market_id == 1, 0); // Assert market ID.
         // Register another market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         assert!(market_id == 2, 0); // Assert market ID.
         let markets_tablist_ref = // Immutably borrow markets tablist.
             &borrow_global<Registry>(@econia).market_id_to_info;
@@ -2157,7 +2168,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test]
@@ -2176,7 +2187,7 @@ module econia::registry {
         // Attempt invalid invocation.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, coin::zero());
+            &underwriter_capability, coin::zero(), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
     }
@@ -2200,7 +2211,7 @@ module econia::registry {
         // Attempt invalid invocation.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, coin::zero());
+            &underwriter_capability, coin::zero(), false);
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
     }
@@ -2217,7 +2228,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(1));
+            lot_size, tick_size, min_size, assets::mint_test(1), false);
     }
 
     #[test]
@@ -2232,7 +2243,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test]
@@ -2247,7 +2258,7 @@ module econia::registry {
         let min_size = 1;
         // Attempt invalid invocation.
         register_market_base_coin_internal<QC, GenericAsset, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test]
@@ -2264,10 +2275,10 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register valid market.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee));
+            lot_size, tick_size, min_size, assets::mint_test(fee), false);
         // Attempt invalid re-registration.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test]
@@ -2282,7 +2293,7 @@ module econia::registry {
         let min_size = 1;
         // Attempt invalid invocation.
         register_market_base_coin_internal<QC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test]
@@ -2297,7 +2308,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero());
+            lot_size, tick_size, min_size, coin::zero(), false);
     }
 
     #[test(account = @econia)]
@@ -2318,7 +2329,7 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee));
+            lot_size, tick_size, min_size, assets::mint_test(fee), false);
         // Attempt invalid invocation.
         remove_recognized_market(account, market_id);
     }
@@ -2354,11 +2365,11 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee));
+            lot_size, tick_size, min_size, assets::mint_test(fee), false);
         set_recognized_market(account, market_id); // Set as recognized.
         // Register different market with same trading pair, storing ID.
         let market_id_2 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size - 1, tick_size, min_size, assets::mint_test(fee));
+            lot_size - 1, tick_size, min_size, assets::mint_test(fee), false);
         // Attempt invalid invocation.
         remove_recognized_market(account, market_id_2);
     }
@@ -2397,9 +2408,9 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register markets, storing IDs.
         let market_id_1 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_1, tick_size_1, min_size_1, assets::mint_test(fee));
+            lot_size_1, tick_size_1, min_size_1, assets::mint_test(fee), false);
         let market_id_2 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee));
+            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee), false);
         // Set first market as recognized.
         set_recognized_market(account, market_id_1);
         // Assert lookup.
@@ -2476,10 +2487,10 @@ module econia::registry {
         assert!(!has_recognized_market_base_coin_by_type<BC, QC>(), 0);
         assert!(get_market_id_base_generic<QC>(
                     base_name_generic, lot_size_1, tick_size_1, min_size_1,
-                    underwriter_id_generic)
+                    underwriter_id_generic, false)
                 == option::none(), 0);
         assert!(get_market_id_base_coin<BC, QC>(
-                    lot_size_2, tick_size_2, min_size_2) == option::none(), 0);
+                    lot_size_2, tick_size_2, min_size_2, false) == option::none(), 0);
         // Assert events.
         let market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
@@ -2487,9 +2498,9 @@ module econia::registry {
         // Register markets.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size_1, tick_size_1, min_size_1,
-            &underwriter_capability, assets::mint_test(fee));
+            &underwriter_capability, assets::mint_test(fee), false);
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee));
+            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee), false);
         // Assert events.
         market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
@@ -2588,10 +2599,10 @@ module econia::registry {
         assert!(has_recognized_market_base_coin_by_type<BC, QC>(), 0);
         assert!(get_market_id_base_generic<QC>(
                     base_name_generic, lot_size_1, tick_size_1, min_size_1,
-                    underwriter_id_generic)
+                    underwriter_id_generic, false)
                 == option::some(1), 0);
         assert!(get_market_id_base_coin<BC, QC>(
-                    lot_size_2, tick_size_2, min_size_2)
+                    lot_size_2, tick_size_2, min_size_2, false)
                 == option::some(2), 0);
         // Assert generic asset market info.
         let (market_id, lot_size, tick_size, min_size, underwriter_id) =
@@ -2675,7 +2686,7 @@ module econia::registry {
         // Register a third market having the same trading pair as the
         // second market, and set it as recognized.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_3, tick_size_3, min_size_3, assets::mint_test(fee));
+            lot_size_3, tick_size_3, min_size_3, assets::mint_test(fee), false);
         set_recognized_markets(econia, vector[3]);
         // Verify that second market, which has same trading pair, is
         // not marked as recognized.

--- a/src/move/econia/sources/registry.move
+++ b/src/move/econia/sources/registry.move
@@ -287,11 +287,7 @@ module econia::registry {
         /// underwriter capability required to verify generic asset
         /// amounts. A market-wide ID that only applies to markets
         /// having a generic base asset.
-        underwriter_id: u64,
-
-        /// Is this market full custodian.
-        /// Only custodian functions can place orders on full custodian markets
-        is_custodian: bool,
+        underwriter_id: u64
     }
 
     /// Human-readable market info return for view functions.
@@ -537,7 +533,6 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        is_custodian: bool,
     ): Option<u64>
     acquires Registry {
         get_market_id(MarketInfo{
@@ -547,8 +542,7 @@ module econia::registry {
             lot_size,
             tick_size,
             min_size,
-            underwriter_id: NO_UNDERWRITER,
-            is_custodian
+            underwriter_id: NO_UNDERWRITER
         })
     }
 
@@ -567,8 +561,7 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        underwriter_id: u64,
-        is_custodian: bool,
+        underwriter_id: u64
     ): Option<u64>
     acquires Registry {
         get_market_id(MarketInfo{
@@ -578,8 +571,7 @@ module econia::registry {
             lot_size,
             tick_size,
             min_size,
-            underwriter_id,
-            is_custodian,
+            underwriter_id
         })
     }
 
@@ -1347,8 +1339,7 @@ module econia::registry {
         lot_size: u64,
         tick_size: u64,
         min_size: u64,
-        utility_coins: Coin<UtilityCoinType>,
-        is_custodian: bool,
+        utility_coins: Coin<UtilityCoinType>
     ): u64
     acquires Registry {
         // Assert base coin type is initialized.
@@ -1357,7 +1348,7 @@ module econia::registry {
         // market ID.
         register_market_internal<QuoteCoinType, UtilityCoinType>(
             type_info::type_of<BaseCoinType>(), string::utf8(b""), lot_size,
-            tick_size, min_size, NO_UNDERWRITER, utility_coins, is_custodian)
+            tick_size, min_size, NO_UNDERWRITER, utility_coins)
     }
 
     /// Wrapped market registration call for a generic base type,
@@ -1386,8 +1377,7 @@ module econia::registry {
         tick_size: u64,
         min_size: u64,
         underwriter_capability_ref: &UnderwriterCapability,
-        utility_coins: Coin<UtilityCoinType>,
-        is_custodian: bool,
+        utility_coins: Coin<UtilityCoinType>
     ): u64
     acquires Registry {
         // Get generic asset name length.
@@ -1404,7 +1394,7 @@ module econia::registry {
         // market ID.
         register_market_internal<QuoteCoinType, UtilityCoinType>(
             type_info::type_of<GenericAsset>(), base_name_generic, lot_size,
-            tick_size, min_size, underwriter_id, utility_coins, is_custodian)
+            tick_size, min_size, underwriter_id, utility_coins)
     }
 
     // Public friend functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -1573,8 +1563,7 @@ module econia::registry {
         tick_size: u64,
         min_size: u64,
         underwriter_id: u64,
-        utility_coins: Coin<UtilityCoinType>,
-        is_custodian: bool,
+        utility_coins: Coin<UtilityCoinType>
     ): u64
     acquires Registry {
         // Assert lot size is nonzero.
@@ -1591,7 +1580,7 @@ module econia::registry {
         assert!(base_type != quote_type, E_BASE_QUOTE_SAME);
         let market_info = MarketInfo{ // Pack market info.
             base_type, base_name_generic, quote_type, lot_size, tick_size,
-            min_size, underwriter_id, is_custodian};
+            min_size, underwriter_id};
         // Mutably borrow registry.
         let registry_ref_mut = borrow_global_mut<Registry>(@econia);
         // Mutably borrow map from market info to market ID.
@@ -1764,10 +1753,10 @@ module econia::registry {
         // Register markets.
         let market_id_pure_coin = register_market_base_coin_internal<
             BC, QC, UC>(lot_size_pure_coin, tick_size_pure_coin,
-            min_size_pure_coin, assets::mint_test(fee), false);
+            min_size_pure_coin, assets::mint_test(fee));
         let market_id_generic = register_market_base_generic_internal<QC, UC>(
             base_name_generic_generic, lot_size_generic, tick_size_generic,
-            min_size_generic, &underwriter_capability, assets::mint_test(fee), false);
+            min_size_generic, &underwriter_capability, assets::mint_test(fee));
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         // Return market info.
@@ -1820,7 +1809,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types.
@@ -1856,7 +1845,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types (invalid base).
@@ -1896,7 +1885,7 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         let (base_type, quote_type) = // Get asset types (wrong quote).
@@ -2085,11 +2074,11 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing market ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size - 1, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size - 1, tick_size, min_size, assets::mint_test(fee));
         assert!(market_id == 1, 0); // Assert market ID.
         // Register another market, storing market ID.
         market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size, tick_size, min_size, assets::mint_test(fee));
         assert!(market_id == 2, 0); // Assert market ID.
         let markets_tablist_ref = // Immutably borrow markets tablist.
             &borrow_global<Registry>(@econia).market_id_to_info;
@@ -2128,12 +2117,12 @@ module econia::registry {
         // Register market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size - 1, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         assert!(market_id == 1, 0); // Assert market ID.
         // Register another market, storing market ID.
         let market_id = register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         assert!(market_id == 2, 0); // Assert market ID.
         let markets_tablist_ref = // Immutably borrow markets tablist.
             &borrow_global<Registry>(@econia).market_id_to_info;
@@ -2168,7 +2157,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test]
@@ -2187,7 +2176,7 @@ module econia::registry {
         // Attempt invalid invocation.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, coin::zero(), false);
+            &underwriter_capability, coin::zero());
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
     }
@@ -2211,7 +2200,7 @@ module econia::registry {
         // Attempt invalid invocation.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size, tick_size, min_size,
-            &underwriter_capability, coin::zero(), false);
+            &underwriter_capability, coin::zero());
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
     }
@@ -2228,7 +2217,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(1), false);
+            lot_size, tick_size, min_size, assets::mint_test(1));
     }
 
     #[test]
@@ -2243,7 +2232,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test]
@@ -2258,7 +2247,7 @@ module econia::registry {
         let min_size = 1;
         // Attempt invalid invocation.
         register_market_base_coin_internal<QC, GenericAsset, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test]
@@ -2275,10 +2264,10 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register valid market.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size, tick_size, min_size, assets::mint_test(fee));
         // Attempt invalid re-registration.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test]
@@ -2293,7 +2282,7 @@ module econia::registry {
         let min_size = 1;
         // Attempt invalid invocation.
         register_market_base_coin_internal<QC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test]
@@ -2308,7 +2297,7 @@ module econia::registry {
         let min_size = 0;
         // Attempt invalid invocation.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, coin::zero(), false);
+            lot_size, tick_size, min_size, coin::zero());
     }
 
     #[test(account = @econia)]
@@ -2329,7 +2318,7 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size, tick_size, min_size, assets::mint_test(fee));
         // Attempt invalid invocation.
         remove_recognized_market(account, market_id);
     }
@@ -2365,11 +2354,11 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register market, storing ID.
         let market_id = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size, tick_size, min_size, assets::mint_test(fee));
         set_recognized_market(account, market_id); // Set as recognized.
         // Register different market with same trading pair, storing ID.
         let market_id_2 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size - 1, tick_size, min_size, assets::mint_test(fee), false);
+            lot_size - 1, tick_size, min_size, assets::mint_test(fee));
         // Attempt invalid invocation.
         remove_recognized_market(account, market_id_2);
     }
@@ -2408,9 +2397,9 @@ module econia::registry {
         let fee = incentives::get_market_registration_fee();
         // Register markets, storing IDs.
         let market_id_1 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_1, tick_size_1, min_size_1, assets::mint_test(fee), false);
+            lot_size_1, tick_size_1, min_size_1, assets::mint_test(fee));
         let market_id_2 = register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee), false);
+            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee));
         // Set first market as recognized.
         set_recognized_market(account, market_id_1);
         // Assert lookup.
@@ -2487,10 +2476,10 @@ module econia::registry {
         assert!(!has_recognized_market_base_coin_by_type<BC, QC>(), 0);
         assert!(get_market_id_base_generic<QC>(
                     base_name_generic, lot_size_1, tick_size_1, min_size_1,
-                    underwriter_id_generic, false)
+                    underwriter_id_generic)
                 == option::none(), 0);
         assert!(get_market_id_base_coin<BC, QC>(
-                    lot_size_2, tick_size_2, min_size_2, false) == option::none(), 0);
+                    lot_size_2, tick_size_2, min_size_2) == option::none(), 0);
         // Assert events.
         let market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
@@ -2498,9 +2487,9 @@ module econia::registry {
         // Register markets.
         register_market_base_generic_internal<QC, UC>(
             base_name_generic, lot_size_1, tick_size_1, min_size_1,
-            &underwriter_capability, assets::mint_test(fee), false);
+            &underwriter_capability, assets::mint_test(fee));
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee), false);
+            lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee));
         // Assert events.
         market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
@@ -2599,10 +2588,10 @@ module econia::registry {
         assert!(has_recognized_market_base_coin_by_type<BC, QC>(), 0);
         assert!(get_market_id_base_generic<QC>(
                     base_name_generic, lot_size_1, tick_size_1, min_size_1,
-                    underwriter_id_generic, false)
+                    underwriter_id_generic)
                 == option::some(1), 0);
         assert!(get_market_id_base_coin<BC, QC>(
-                    lot_size_2, tick_size_2, min_size_2, false)
+                    lot_size_2, tick_size_2, min_size_2)
                 == option::some(2), 0);
         // Assert generic asset market info.
         let (market_id, lot_size, tick_size, min_size, underwriter_id) =
@@ -2686,7 +2675,7 @@ module econia::registry {
         // Register a third market having the same trading pair as the
         // second market, and set it as recognized.
         register_market_base_coin_internal<BC, QC, UC>(
-            lot_size_3, tick_size_3, min_size_3, assets::mint_test(fee), false);
+            lot_size_3, tick_size_3, min_size_3, assets::mint_test(fee));
         set_recognized_markets(econia, vector[3]);
         // Verify that second market, which has same trading pair, is
         // not marked as recognized.

--- a/src/move/econia/sources/registry.move
+++ b/src/move/econia/sources/registry.move
@@ -1271,7 +1271,7 @@ module econia::registry {
     /// * `test_get_market_info_for_market_account_invalid_base()`
     /// * `test_get_market_info_for_market_account_invalid_market_id()`
     /// * `test_get_market_info_for_market_account_invalid_quote()`
-    public(friend) fun get_market_info_for_market_account(
+    public fun get_market_info_for_market_account(
         market_id: u64,
         base_type: TypeInfo,
         quote_type: TypeInfo


### PR DESCRIPTION
Added some getters for use in external move modules.
Public methods for place/cancel order now return events.

Add external fields to CancelOrderEvent to extend information about canceled order